### PR TITLE
fixes #42. Update the color scheme to be consistent

### DIFF
--- a/tmdb/static/css/style.css
+++ b/tmdb/static/css/style.css
@@ -3,7 +3,7 @@ body {
 }
 
 .team_match_at_ring {
-  background-color: cyan !important;
+  background-color: orange !important;
 }
 
 .team_match_sent_to_ring {
@@ -11,7 +11,11 @@ body {
 }
 
 .team_match_in_holding {
-  background-color: lightskyblue !important;
+  background-color: yellow !important;
+}
+
+.team_match_complete {
+    background-color: green !important;
 }
 
 .errorlist {


### PR DESCRIPTION
Made tweaks so that these are the new colors for the match background: 
- Holding: Yellow
- At Ring: Blue 
- Done: Green

Did not make the header sticky, but thought that I would wait on that in light for the changes needed for React.