### PR TITLE
Fixes #62. Adds a spinner for loading 

### DIFF
--- a/tmdb/static/css/style.css
+++ b/tmdb/static/css/style.css
@@ -130,3 +130,20 @@ body {
 .main .page-header {
   margin-top: 0;
 }
+
+#loader {
+    border: 16px solid #f3f3f3; /* Light grey */
+    border-top: 16px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 100px;
+    height: 100px;
+    animation: spin 2s linear infinite;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/tmdb/static/js/match_websocket.js
+++ b/tmdb/static/js/match_websocket.js
@@ -166,6 +166,7 @@ function set_school_filter() {
 }
 
 function add_filter_options() {
+  document.getElementById('filter-label').innerHTML = "Filter matches:"
   var filter_div = document.getElementById('filter_type');
   var filter_type_elem = document.createElement('select');
   filter_div.append(filter_type_elem);
@@ -462,6 +463,8 @@ function on_websocket_open() {
   init_data_req.onreadystatechange = function() {
     if (init_data_req.readyState == 4 && init_data_req.status == 200) {
       store_initial_data(init_data_req.responseText);
+      // Hide the loader if the data has been loaded.
+      document.getElementById("loader").style = "display:none";
       render_initial_display();
       return;
     }

--- a/tmdb/templates/tmdb/snippets/match_table_component.html
+++ b/tmdb/templates/tmdb/snippets/match_table_component.html
@@ -1,10 +1,13 @@
-<div id="action-bar">
-  <label for="filters" style="display: inline-block">Filter matches</label>
-  <div id="filter_type" style="display: inline-block"></div>
-  <div id="filter_value" style="display: inline-block"></div>
-</div>
+<div id="content">
+    <div id="action-bar">
+        <label for="filters" style="display: inline-block" id="filter-label"></label>
+        <div id="filter_type" style="display: inline-block"></div>
+        <div id="filter_value" style="display: inline-block"></div>
+    </div>
 
-{% include 'tmdb/snippets/match_list.html' with tournament=tournament team_matches=all_matches only %}
+    {% include 'tmdb/snippets/match_list.html' with tournament=tournament team_matches=all_matches only %}
 
-<div class="division-queue">
+    <div class="division-queue">
+    </div>
 </div>
+<div id="loader"></div>


### PR DESCRIPTION
Adds a loading spinner that goes away when the data is ready to be rendered. 

Here is a screenshot of what this looks like: 
![loading_spinner](https://user-images.githubusercontent.com/553277/36067457-b0269524-0e8b-11e8-8652-31d9df2e15c7.png)

It's not perfectly vertically aligned but I think it is fine for now. 