### PR TITLE
Custom settings

### DIFF
--- a/ectc_tm_server/generate_custom_settings.py
+++ b/ectc_tm_server/generate_custom_settings.py
@@ -5,10 +5,10 @@ from django.core.management.utils import get_random_secret_key
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = get_random_secret_key()
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 # Write out the python file
 file = open("custom_settings.py","w")
 file.write("SECRET_KEY=\"" + SECRET_KEY +"\"\n")
 file.write("DEBUG=" + str(DEBUG) + "\n")
-file.write("ALLOWED_HOSTS = [\"localhost\"]\n")
+file.write("ALLOWED_HOSTS = ['www.ectc-tournaments.org', 'ectc-tournaments.org', '198.98.59.77']\n")


### PR DESCRIPTION
I don't want to break the old way of building the web server (without Docker), so I kept the default settings in server.py. They can be overwritten by the generated custom_settings.py file.