### PR TITLE
Added support for poomsae division

### DIFF
--- a/ectc_tm_server/generate_custom_settings.py
+++ b/ectc_tm_server/generate_custom_settings.py
@@ -12,3 +12,4 @@ with open("custom_settings.py","w") as fh:
     fh.write("SECRET_KEY=\"" + SECRET_KEY +"\"\n")
     fh.write("DEBUG=" + str(DEBUG) + "\n")
     fh.write("ALLOWED_HOSTS = [\"localhost\"]\n")
+    fh.write("REDIS_HOST = \"localhost\"\n")

--- a/ectc_tm_server/settings.py
+++ b/ectc_tm_server/settings.py
@@ -19,7 +19,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 current_dir = os.path.dirname(os.path.realpath("__file__"))
 sys.path.insert(0, current_dir)
 try:
-    from .custom_settings import SECRET_KEY, DEBUG, ALLOWED_HOSTS
+    from .custom_settings import SECRET_KEY, DEBUG, ALLOWED_HOSTS, REDIS_HOST
 except:
     raise IOError("Unable to read configuration from custom settings")
 sys.path.pop(0)

--- a/tmdb/models.py
+++ b/tmdb/models.py
@@ -42,10 +42,12 @@ class SparringDivisionLevelField(models.CharField):
     A_TEAM_VAL = 'A'
     B_TEAM_VAL = 'B'
     C_TEAM_VAL = 'C'
+    POOMSAE_TEAM_VAL = 'P'
     DIVISION_LEVEL_CHOICES = (
         (A_TEAM_VAL, 'A-team'),
         (B_TEAM_VAL, 'B-team'),
         (C_TEAM_VAL, 'C-team'),
+        (POOMSAE_TEAM_VAL, 'Poomsae-team'),
     )
 
     DIVISION_LEVEL_LABELS = dict(DIVISION_LEVEL_CHOICES)

--- a/tmdb/util/team_file_importer.py
+++ b/tmdb/util/team_file_importer.py
@@ -16,6 +16,7 @@ DIVISION_NAMES = [
     "Women's B",
     "Men's C",
     "Women's C",
+    "Poomsae"
 ]
 
 def _generate_division_re(division_name):
@@ -69,6 +70,9 @@ def _parse_num_teams(num_teams_row):
     return num_teams
 
 def _get_sparring_division(division_name):
+    if division_name.strip().startswith("Poomsae"):
+        return models.SparringDivision.objects.get(sex=models.SexField.FEMALE, skill_level="P")
+
     sex = division_name[:-1].strip()
     skill_level = division_name[-1:]
     if sex == "Men's":


### PR DESCRIPTION
Added support for poomsae division by adding a "P" choice to `SparringDivisionLevelField`. However, when creating a `Tournament` object, it will take the cross product between all `SexField` choices and `SparringDivisionLevelField` choices, so there will be separate Female Poomsae and Male Poomsae.

The script to parse the team csv file has also been updated to support poomsae division. The format is expected be the same as the other division and each team name should be of the form "{school name} Poomsae{team number} - (LMH)" (e.g, "Cornell University Poomsae2 - (LMH)" will refer to Cornell's 2nd poomsame team). This will create a team in the **Women's** Poomsae divsion. The LMH don't really have any meaning in this context but are there to keep things consistent.

**This is a giant hack, but should work for now** 